### PR TITLE
Hibás fiók linkek szerkesztése

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ A bővítmény jelenleg az alábbi e-KRÉTA oldalakat támogatja:
 ## 👥 Csapat
 
 - **[Zan1456](https://github.com/Zan1456)** - Vezető Fejlesztő
-- **[BalazsManus](https://github.com/BalazsManus)** - Fejlesztő
-- **[Xou](https://github.com/Xou)** - Designer
+- **[BalazsManus](https://github.com/olajcsere)** - Fejlesztő
+- **[Xou](https://yoursit.ee/xou)** - Designer
 
 ## 🤝 Közreműködés
 


### PR DESCRIPTION
https://discord.com/channels/1111649116020285532/1111798771513303102/1352946310004740168
Nem létező / feltételezésem szerint rossz fiók linkek voltak megadva, ezt javítottam arra amit találtam.