### PR TITLE
docs: GNU GPLv3 is **not** GNU AGPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A bővítmény jelenleg az alábbi e-KRÉTA oldalakat támogatja:
 
 ## 📝 Licensz
 
-A projekt [GNU General Public License v3.0](LICENSE) alatt jelent meg. További információért lásd a LICENSE fájlt.
+A projekt [GNU Affero General Public License v3.0](LICENSE) alatt jelent meg. További információért lásd a LICENSE fájlt.
 
 ## 💬 Kapcsolat
 


### PR DESCRIPTION
egész korrekt a dolog, de azért jobb tisztában lenni milyen licensz-szel(fene tudja hogy kell ezt magyarul írni) van publikálva, ne legyen ebből több probléma légyszi
